### PR TITLE
Implemented optimal CMAC calculation for WebCrypto

### DIFF
--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -15,7 +15,7 @@ export interface IBlockCipher {
 
   /** Encrypt 16-byte block in-place, replacing its contents with ciphertext. */
   encryptBlock(block: Block): Promise<this>;
-  
+
   /** Encrypt batched data with CBC for optimal CMAC calculation. */
   encryptBlockBatch(block: Block, data: Uint8Array): Promise<this>;
 }

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -15,6 +15,9 @@ export interface IBlockCipher {
 
   /** Encrypt 16-byte block in-place, replacing its contents with ciphertext. */
   encryptBlock(block: Block): Promise<this>;
+  
+  /** Encrypt batched data with CBC for optimal CMAC calculation. */
+  encryptBlockBatch(block: Block, data: Uint8Array): Promise<this>;
 }
 
 /**

--- a/src/mac/cmac.ts
+++ b/src/mac/cmac.ts
@@ -82,7 +82,7 @@ export class CMAC implements IMACLike {
       const subkey = (padding > 0) ? this._subkey2 : this._subkey1;
 
       // XOR in the subkey.
-      for (let i = 0 ; i < Block.SIZE ; ++i ) {
+      for (let i = 0; i < Block.SIZE; ++i) {
         allData[totalLength - Block.SIZE + i] ^= subkey.data[i];
       }
 

--- a/src/mac/cmac.ts
+++ b/src/mac/cmac.ts
@@ -3,7 +3,6 @@
 
 import { IBlockCipher, ICryptoProvider, IMACLike } from "../interfaces";
 import Block from "../internals/block";
-import { xor } from "../internals/xor";
 
 /**
  * The AES-CMAC message authentication code
@@ -27,6 +26,7 @@ export class CMAC implements IMACLike {
   private _buffer: Block;
   private _bufferPos = 0;
   private _finished = false;
+  private _data_accum = new Array();
 
   constructor(
     private _cipher: IBlockCipher,
@@ -40,6 +40,7 @@ export class CMAC implements IMACLike {
     this._buffer.clear();
     this._bufferPos = 0;
     this._finished = false;
+    this._data_accum = new Array();
     return this;
   }
 
@@ -50,54 +51,51 @@ export class CMAC implements IMACLike {
   }
 
   public async update(data: Uint8Array): Promise<this> {
-    const left = Block.SIZE - this._bufferPos;
-    let dataPos = 0;
-    let dataLength = data.length;
-
-    if (dataLength > left) {
-      for (let i = 0; i < left; i++) {
-        this._buffer.data[this._bufferPos + i] ^= data[i];
-      }
-      dataLength -= left;
-      dataPos += left;
-      await this._cipher.encryptBlock(this._buffer);
-      this._bufferPos = 0;
-    }
-
-    if (dataLength > Block.SIZE) {
-      const batchSize = Math.floor((dataLength - 1) / Block.SIZE);
-      const fullBlockEndPos = dataPos + batchSize * Block.SIZE;
-      const fwdBlock = data.slice(dataPos, fullBlockEndPos);
-      dataLength -= batchSize * Block.SIZE;
-      dataPos = fullBlockEndPos;
-
-      await this._cipher.encryptBlockBatch(this._buffer, fwdBlock);
-    }
-
-    for (let i = 0; i < dataLength; i++) {
-      this._buffer.data[this._bufferPos++] ^= data[dataPos + i];
-    }
-
+    this._data_accum.push(data);
     return this;
   }
 
   public async finish(): Promise<Uint8Array> {
     if (!this._finished) {
-      // Select which subkey to use.
-      const subkey = (this._bufferPos < Block.SIZE) ? this._subkey2 : this._subkey1;
-
-      // XOR in the subkey.
-      xor(this._buffer.data, subkey.data);
-
-      // Pad if needed.
-      if (this._bufferPos < Block.SIZE) {
-        this._buffer.data[this._bufferPos] ^= 0x80;
+      // calculate total length and padding
+      let totalLength = this._data_accum.reduce((acc, value) => acc + value.length, 0);
+      let padding;
+      if (totalLength === 0) {
+        totalLength = padding = Block.SIZE;
+      } else {
+        padding = totalLength % Block.SIZE;
+        if (padding > 0) {
+          padding = Block.SIZE - padding;
+          totalLength += padding;
+        }
       }
 
-      // Encrypt buffer to get the final digest.
-      await this._cipher.encryptBlock(this._buffer);
+      // construct single buffer with all data
+      const allData = new Uint8Array(totalLength);
+      let bufPos = 0;
+      for (const data of this._data_accum) {
+        allData.set(data, bufPos);
+        bufPos += data.length;
+      }
 
-      // Set finished flag.
+      // Select which subkey to use.
+      const subkey = (padding > 0) ? this._subkey2 : this._subkey1;
+
+      // XOR in the subkey.
+      for (let i = 0 ; i < Block.SIZE ; ++i ) {
+        allData[totalLength - Block.SIZE + i] ^= subkey.data[i];
+      }
+
+      // Pad if needed.
+      if (padding > 0) {
+        allData[totalLength - padding] ^= 0x80;
+      }
+
+      // Encrypt the full buffer to get the final digest.
+      await this._cipher.encryptBlockBatch(this._buffer, allData);
+
+      // Free the accumulation buffer and set finished flag.
+      this._data_accum = new Array();
       this._finished = true;
     }
 

--- a/src/providers/soft/aes.ts
+++ b/src/providers/soft/aes.ts
@@ -193,6 +193,22 @@ export default class SoftAes implements IBlockCipher {
 
     return this._emptyPromise;
   }
+
+  /**
+   * Encrypt batched data with CBC. This is made to be suitable for use in CMAC calculation.
+   * NOTE: This does not provide better performance compared to using encryptBlock(...) directly like before.
+   */
+  public async encryptBlockBatch(block: Block, data: Uint8Array): Promise<this> {
+    let dataPos = 0;
+    while (dataPos < data.length) {
+      for (let i = 0; i < Block.SIZE; i++) {
+        block.data[i] ^= data[dataPos + i];
+      }
+      dataPos += Block.SIZE;
+      await this.encryptBlock(block);
+    }
+    return this._emptyPromise;
+  }
 }
 
 // Initialize generates encryption and decryption tables.

--- a/src/providers/webcrypto/aes.ts
+++ b/src/providers/webcrypto/aes.ts
@@ -72,4 +72,19 @@ export default class WebCryptoAes implements IBlockCipher {
     block.data.set(new Uint8Array(ctBlock, 0, Block.SIZE));
     return this._emptyPromise;
   }
+
+  /**
+   * Encrypt data with CBC in a batch.
+   * This is made to be suitable and as optimal as possible for use in CMAC calculation.
+   *
+   * @param {Block} block - block to use as iv, final block of ciphertext will replace its contents
+   * @param {Uint8Array} data - data to encrypt
+   * @returns {Promise<this>}
+   */
+  public async encryptBlockBatch(block: Block, data: Uint8Array): Promise<this> {
+    const params = { name: "AES-CBC", iv: block.data };
+    const ctBlock = await this._crypto.subtle.encrypt(params, this._key, data);
+    block.data.set(new Uint8Array(ctBlock, data.length - Block.SIZE, Block.SIZE));
+    return this._emptyPromise;
+  }
 }


### PR DESCRIPTION
I've found myself in a situation where this AES-SIV implementation would be great for use, but its performance was very lacking.

After digging a bit I've found that the CMAC calculation is very badly optimized and (unlike the PMAC) it should be trivial to improve.

I've basically solved the TODO in the `cmac.ts` that said: `use AES-CBC with a span of multiple blocks instead of encryptBlock to encrypt many blocks in a single call to the WebCrypto API`.

I've added the necessary interface changes and compatibility for the software aes fallback provider. Of course the performance of that is not any better. Unit tests are still passing.

In summary this change improved the performance of AES-CMAC-SIV.
For example, the encoding performance improved from  400KB/s to 120MB/s!