### PR TITLE
Correct WebCrypto API parameter value from bytes to bits

### DIFF
--- a/src/providers/webcrypto/aes_ctr.ts
+++ b/src/providers/webcrypto/aes_ctr.ts
@@ -21,7 +21,7 @@ export default class WebCryptoAesCtr implements ICTRLike {
 
   public async encryptCtr(iv: Uint8Array, plaintext: Uint8Array): Promise<Uint8Array> {
     const ciphertext = await this.crypto.subtle.encrypt(
-      { name: "AES-CTR", counter: iv, length: 16 },
+      { name: "AES-CTR", counter: iv, length: 128 },
       this.key,
       plaintext,
     );


### PR DESCRIPTION
The encrypt call for AES-CTR by the WebCrypto provider is incorrect. The `length` parameter indicating the number of rightmost bits to be used for incrementing should be `128` to be consistent with other implementations.

I've checked to see how the SoftCrypto provider, the python version of miscreant and the AES-SIV available in pycryptodome configures the CTR. They all allow the CTR to use the whole range for counting. Other limitations may apply that I'm unaware of and it seems the programmer must pay attention to security limits of the counter as described in RFC 5297 section 2.5.

The current value of `16` overflows at a bigger than 1MB message and the WebCrypto API raises an exception.

I've tested the change up to 32MB payloads and they work correctly.